### PR TITLE
add zfs_exporter version information

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,15 @@ abandoned completely and merged into node_exporter**
 This currently exposes all basic stats (vdev_stats) and most extended stats (vdev_stats_ex) on a
 vdev-level. It doesn't expose per-disk or per-zpool stats, even though these are also available from
 the underlying API.
+
+
+## Building with version information
+
+```sh
+go build -ldflags="-s -w
+  -X github.com/prometheus/common/version.Version=$(git describe --tags --dirty --always)
+  -X github.com/prometheus/common/version.BuildUser=$(whoami)
+  -X github.com/prometheus/common/version.BuildDate=$(date +%Y-%m-%d)
+  -X github.com/prometheus/common/version.Revision=$(git rev-parse --short HEAD)
+  -X github.com/prometheus/common/version.Branch=$(git rev-parse --abbrev-ref HEAD)"
+```

--- a/go.mod
+++ b/go.mod
@@ -5,4 +5,5 @@ go 1.16
 require (
 	git.dolansoft.org/lorenz/go-zfs v0.0.0-20210913192337-a82716998b75
 	github.com/prometheus/client_golang v1.11.0
+	github.com/prometheus/common v0.26.0
 )

--- a/main.go
+++ b/main.go
@@ -10,10 +10,12 @@ import (
 	"git.dolansoft.org/lorenz/go-zfs/ioctl"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/prometheus/common/version"
 )
 
 var (
 	listenAddr = flag.String("listen-addr", ":9700", "Address the ZFS exporter should listen on")
+	versionOpt = flag.Bool("version", false, "Show version and exit")
 )
 
 type stat struct {
@@ -221,12 +223,19 @@ func (c *zfsCollector) Collect(ch chan<- prometheus.Metric) {
 }
 
 func main() {
+	flag.Parse()
+
+	if (*versionOpt) {
+	    fmt.Println(version.Print("zfs_exporter"))
+	    return
+	}
+
 	ioctl.Init("")
 
 	c := zfsCollector{}
 	prometheus.MustRegister(&c)
+	prometheus.MustRegister(version.NewCollector("zfs_exporter"))
 
-	flag.Parse()
 	http.Handle("/metrics", promhttp.Handler())
 	if err := http.ListenAndServe(*listenAddr, nil); err != nil {
 		log.Fatalf("failed to listen: %v", err)


### PR DESCRIPTION
adds a `--version` flag and a `zfs_exporter_build_info` metric, with tag, date, revision, branch,
using the prometheus/common/version code.

I find it useful even when zfs_exporter is in development to track deployed version